### PR TITLE
Show correct parser class

### DIFF
--- a/src/Parsers/Behat.php
+++ b/src/Parsers/Behat.php
@@ -44,7 +44,7 @@ class Behat implements ParserInterface
                         $line->getCommit()->getAuthorName(),
                         $line->getCommit()->getAuthorEmail(),
                         $line->getCommit()->getCommitterDate()->getTimestamp(),
-                        self::class
+                        static::class
                     );
                 }
             }

--- a/src/Parsers/Codeception/Cept.php
+++ b/src/Parsers/Codeception/Cept.php
@@ -40,7 +40,7 @@ class Cept implements ParserInterface
                 $line->getCommit()->getAuthorName(),
                 $line->getCommit()->getAuthorEmail(),
                 $line->getCommit()->getCommitterDate()->getTimestamp(),
-                self::class
+                static::class
             );
         }
 

--- a/src/Parsers/Codeception/Cest.php
+++ b/src/Parsers/Codeception/Cest.php
@@ -45,7 +45,7 @@ class Cest implements ParserInterface
                         $line->getCommit()->getAuthorName(),
                         $line->getCommit()->getAuthorEmail(),
                         $line->getCommit()->getCommitterDate()->getTimestamp(),
-                        self::class
+                        static::class
                     );
                 }
             }

--- a/src/Parsers/JavaScript/BaseJavaScriptParser.php
+++ b/src/Parsers/JavaScript/BaseJavaScriptParser.php
@@ -40,7 +40,7 @@ abstract class BaseJavaScriptParser extends BaseParser
                         $line->getCommit()->getAuthorName(),
                         $line->getCommit()->getAuthorEmail(),
                         $line->getCommit()->getCommitterDate()->getTimestamp(),
-                        self::class
+                        static::class
                     );
                 }
             }

--- a/src/Parsers/PhpUnit.php
+++ b/src/Parsers/PhpUnit.php
@@ -39,7 +39,7 @@ class PhpUnit extends BaseParser
                         $line->getCommit()->getAuthorName(),
                         $line->getCommit()->getAuthorEmail(),
                         $line->getCommit()->getCommitterDate()->getTimestamp(),
-                        self::class
+                        static::class
                     );
                 }
             }

--- a/tests/Parsers/BaseParserTestCase.php
+++ b/tests/Parsers/BaseParserTestCase.php
@@ -22,6 +22,7 @@ class BaseParserTestCase extends PHPUnit_Framework_TestCase
      * @param ParserInterface $parser
      * @param array $expectedFiles What files do we expect as result
      * @param int $expectedCount How many tests should be counted
+     * @return Result[]
      */
     protected function runParserTest($parser, $expectedFiles, $expectedCount)
     {
@@ -33,6 +34,8 @@ class BaseParserTestCase extends PHPUnit_Framework_TestCase
         foreach ($results as $result) {
             static::assertInstanceOf(Result::class, $result);
 
+            static::assertEquals(get_class($parser), $result->getParser());
+
             if (in_array($result->getFilename(), $expectedFiles)) {
                 $count++;
             }
@@ -42,5 +45,7 @@ class BaseParserTestCase extends PHPUnit_Framework_TestCase
             $count,
             'Check if file list has ' . $expectedCount . ' results.'
         );
+
+        return $results;
     }
 }


### PR DESCRIPTION
Use late static binding to show the correct class as parser with the BaseJavascriptParser.